### PR TITLE
Fix mainContentObserver adding links to modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,33 @@
 # FL 1-Click Wiki
 
-[![License](https://img.shields.io/github/license/lensvol/fl-oneclick-wiki)](https://github.com/lensvol/fl-oneclick-wiki/blob/master/LICENSE) ![GitHub release (latest by date)](https://img.shields.io/github/v/release/lensvol/fl-oneclick-wiki) ![Chrome Web Store](https://img.shields.io/chrome-web-store/v/ceakejjcdgbcocopkdkhiakkohpahien) ![Mozilla Add-on](https://img.shields.io/amo/v/fl-1-click-wiki) 
+[![License](https://img.shields.io/github/license/lensvol/fl-oneclick-wiki)](https://github.com/lensvol/fl-oneclick-wiki/blob/master/LICENSE) [![GitHub release (latest by date)](https://img.shields.io/github/v/release/lensvol/fl-oneclick-wiki)](https://github.com/lensvol/fl-oneclick-wiki/releases) [![Chrome Web Store](https://img.shields.io/chrome-web-store/v/ceakejjcdgbcocopkdkhiakkohpahien)](https://chrome.google.com/webstore/detail/fl-1-click-wiki/ceakejjcdgbcocopkdkhiakkohpahien) [![Mozilla Add-on](https://img.shields.io/amo/v/fl-1-click-wiki)](https://addons.mozilla.org/en-US/firefox/addon/fl-1-click-wiki/)
 
 ![screenshot](https://raw.githubusercontent.com/lensvol/fl-oneclick-wiki/master/screenshot.png)
 
 Simple browser extension for [Fallen London](https://www.fallenlondon.com/) that saves you some clicks on opening FL Wiki pages about specific storylets.
 
-_NB: This extension is **not** yet whitelisted by Failbetter Games. Use at your own risk!_ 
+_NB: This extension is **not** yet whitelisted by Failbetter Games. Use at your own risk!_
 
-Grab it here:
+Grab it from:
 * [Releases page](https://github.com/lensvol/fl-oneclick-wiki/releases) (most up-to-date, see below for instructions)
+* [Firefox Addons](https://addons.mozilla.org/en-US/firefox/addon/fl-1-click-wiki/)
+* [Chrome Web Store](https://chrome.google.com/webstore/detail/fl-1-click-wiki/ceakejjcdgbcocopkdkhiakkohpahien)
 
 ## Manual installation
 
 ### Chrome
 
 1. Download **.ZIP** file from the "Releases" page.
-2. Unzip that file somewhere on your computer. 
+2. Unzip that file somewhere on your computer.
 3. Open _Chrome_.
-4. Go to **chrome://extensions** and 
+4. Go to **chrome://extensions** and
 5. Check the box for "Developer Mode" (top right corner).
 6. Click **Load unpacked extension** and select the folder where you unzipped the file.
 
 ### Mozilla Firefox
 
 1. Download **.ZIP** file from the "Releases" page.
-2. Unzip that file somewhere on your computer. 
+2. Unzip that file somewhere on your computer.
 3. Open **about:debugging** page.
 4. Click **Load Temporary Add-On**
 5. Select any file in the folder where you unzipped the archive.

--- a/README.md
+++ b/README.md
@@ -41,5 +41,4 @@ Grab it here:
 
 ## TODO
 
-* Optional Wiki buttons on branches.
 * Automatically open pre-filled "Search" for non-existent pages.

--- a/inject.js
+++ b/inject.js
@@ -108,7 +108,7 @@
                         mediaRoot = node;
                     }
 
-                    if (mediaRoot) {
+                    if (mediaRoot && !mediaRoot.classList.contains("modal-dialog")) {
                         const actionResults = mediaRoot.parentElement.getElementsByClassName("media--quality-updates")
                         if (actionResults.length > 0) {
                             // This is a page with the action results, they do not have corresponding Wiki pages.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "FL 1-click Wiki",
   "description": "Open corresponding 'Fallen London Wiki' page with one click!",
-  "version": "1.4",
+  "version": "1.4.1",
   "manifest_version": 2,
   "permissions": [
     "https://fallenlondon.wiki/w/api.php"


### PR DESCRIPTION
Fixes small bug where the MutationObserver would add wiki links to the pop-up modal when trying to save a snippet to your journal. 

Also took the liberty of updating the README (removing implemented features from TODO; removing unessential  trailing whitespaces; and adding more visible links to other installation sources) and bumping the version number.

If you'd rather drop any of those commits, or if you want them in a separate PR, please let me know 