### PR TITLE
Feature: support of qualities on myself tab

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -4,9 +4,9 @@
 
     let currentStoryletId = null;
 
-    function createWikiButton() {
+    function createWikiButton(buttonOnly = false, className = "storylet-root__frequency") {
         const containerDiv = document.createElement("div");
-        containerDiv.className = "storylet-root__frequency";
+        containerDiv.className = className;
 
         const buttonlet = document.createElement("button");
         buttonlet.setAttribute("type", "button");
@@ -29,7 +29,7 @@
         buttonlet.appendChild(outerSpan);
         containerDiv.appendChild(buttonlet);
 
-        return containerDiv;
+        return buttonOnly? buttonlet: containerDiv;
     }
 
     function wikiClickListener(container) {

--- a/inject.js
+++ b/inject.js
@@ -10,6 +10,10 @@
     function amIMyself(){
         return document.location.href.startsWith("https://www.fallenlondon.com/myself");
     }
+    /**
+     * @param  {boolean} buttonOnly=false - true iff the surrounding div around the button element should be omitted. 
+     * @param  {string} className="storylet-root__frequency" - CSS class name to give to the div element
+     */
     function createWikiButton(buttonOnly = false, className = "storylet-root__frequency") {
         const containerDiv = document.createElement("div");
         containerDiv.className = className;
@@ -71,6 +75,12 @@
                 const node = mutation.addedNodes[n];
 
                 if (node.nodeName.toLowerCase() === "div") {
+                    // on loading, several elements are inserted into the body
+                    // the div we care for does not have any good identifier,
+                    // so we check for certain elements in its children
+
+                    // first we are looking for the mediaRoot element, which is
+                    // only present on storylets once we have clicked once
                     let mediaRoot = null;
 
                     if (!node.classList.contains("media--root")) {
@@ -100,6 +110,7 @@
                             return;
                         }
 
+                        // this part inserts the button next to the storylet title once you click on the branch
                         let mediaBody = mediaRoot.getElementsByClassName("media__body");
                         if (mediaBody.length > 0) {
                             const container = mediaBody[0];

--- a/inject.js
+++ b/inject.js
@@ -4,6 +4,12 @@
 
     let currentStoryletId = null;
 
+    /**
+     * @returns true iff we are on the Myself tab of the game
+     */
+    function amIMyself(){
+        return document.location.href.startsWith("https://www.fallenlondon.com/myself");
+    }
     function createWikiButton(buttonOnly = false, className = "storylet-root__frequency") {
         const containerDiv = document.createElement("div");
         containerDiv.className = className;
@@ -75,7 +81,12 @@
                     } else {
                         mediaRoot = node;
                     }
+                    const myself = amIMyself();
 
+                    //if we are on myself page
+                    if (myself){
+                        mediaRoot = node.getElementsByClassName("stack-content--3-of-4")[0];
+                    }
                     if (mediaRoot && !mediaRoot.classList.contains("modal-dialog")) {
                         const actionResults = mediaRoot.parentElement.getElementsByClassName("media--quality-updates")
                         if (actionResults.length > 0) {
@@ -113,7 +124,16 @@
 
                     for (const branchContainer of branches) {
                         const branchId = branchContainer.attributes["data-branch-id"].value;
-                        const branchHeader = branchContainer.querySelector("h2[class*='branch__title'], h2[class*='storylet__heading']");
+                        const branchHeader = myself
+                            ? branchContainer.parentNode.querySelector(".quality-item__body")
+                            : branchContainer.querySelector("h2[class*='branch__title'], h2[class*='storylet__heading']");
+                        const lookupValue = myself
+                            ? branchContainer.firstChild.attributes["alt"].value
+                            : branchHeader.textContent;
+
+                        const container = myself
+                            ? branchHeader.firstChild
+                            : branchHeader.parentElement;
                         if (!branchHeader) {
                             continue;
                         }
@@ -141,18 +161,21 @@
                             categories = ["Actions"];
                         }
 
-                        const wikiButton = createWikiButton();
+                        if (myself){
+                            categories = ["Pyramidal Qualities", "Discrete Qualities"];
+                            //TODO: "Qualities" might also work
+                        }
+                        const wikiButton = createWikiButton(myself);
                         wikiButton.addEventListener("click", () => {
                             window.postMessage({
                                 action: "openInFLWiki",
-                                title: branchHeader.textContent,
+                                title: lookupValue,
                                 storyletId: branchId,
                                 filterCategories: categories,
                             })
                         });
 
                         const otherButtons = branchContainer.querySelectorAll("div[class*='buttonlet']");
-                        const container = branchHeader.parentElement;
                         if (otherButtons.length > 0) {
                             container.insertBefore(wikiButton, otherButtons[otherButtons.length - 1].nextSibling);
                         } else {


### PR DESCRIPTION
This PR adds the lookup buttons in front of the quality names on the "Myself" tab. Thus, it allows a quick lookup if you have forgotten what you got the quality for.

The title is extracted from the `alt` attribute of the icon - it's reliable, as opposed to trying to parse it from the actual text.

I must say I am not terribly happy with the resulting layout, and am very open to changes here. In particular, it gets somewhat ugly with qualities that can be uncollapsed, such as "A Patron of..." and "Acquainted With". 