### PR TITLE
add support for more action types

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -138,7 +138,7 @@
                         if (branchContainer.classList.contains("storylet")) {
                             categories = ["Card", "Storylet"];
                         } else {
-                            categories = ["Action"];
+                            categories = ["Action", "Fate Action", "Item Action", "Social Action"] ;
                         }
 
                         const wikiButton = createWikiButton();


### PR DESCRIPTION
This PR implements different action types additionally to the standard "Action".

Justification:

The wiki is now differentiating between different types of actions; the allowed action types are stored in the general list of types game objects can have, [MediaWiki:Smw allows list Has Game Type](https://fallenlondon.wiki/wiki/MediaWiki:Smw_allows_list_Has_Game_Type).

Additionally, the wiki can now list mechanical information on Fate Action rewards, which makes them more interesting to look up on the wiki. They are, however, not stored with the Game Type "Action", but "Fate Action".

