### PR TITLE
Bugfix: use only the main namespace of the wiki

### DIFF
--- a/background.js
+++ b/background.js
@@ -26,6 +26,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         formData.append("action", "askargs");
         formData.append("format", "json");
         formData.append("conditions", conditions);
+        formData.append("parameters", "limit=21");
         formData.append("printouts", "ID");
 
         fetch("https://fallenlondon.wiki/w/api.php", {method: "POST", body: formData})
@@ -42,6 +43,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
                 const entries = Object.entries(result.query.results);
                 if (entries.length > 0) {
+                    if (entries.length > 5){
+                        console.warn(`Wiki server returned ${entries.length} results for the query '${conditions}'.\n`
+                                    + `Please notify the wiki admins about this.`);
+                    }
                     for (let [key, entry] of entries) {
                         console.debug(`Opening tab for ${entry.fullurl}`);
                         openNewTab(entry.fullurl);

--- a/background.js
+++ b/background.js
@@ -5,6 +5,7 @@ function openNewTab(url) {
 function generateConditions(request){
     let conditions = [];
 
+    conditions.push(`:+`); // only request main namespace, i.e. no User:, Help:, etc pages
     conditions.push(`ID::${request.storyletId}`);
 
     if (request.filterCategories) {


### PR DESCRIPTION
The extension currently will request whichever pages happen to have the relevant ID. 

However, users of the wiki sometimes copy existing articles (including ID data) into their user namespace (a page such as "User:FallenLondonWikiUser/Sandbox") to experiment with new functionality. This leads to false positives when said ID gets requested.

This PR fixes the problem by only requesting pages from the main namespace (i.e. the one which doesn't have any prefix).

Additionally, this PR adds a limit on how many pages can be requested, to avoid mishaps during future development. For example, if one were to accidentally remove further constraints during development, one might accidentally request a lot of pages from the main namespace. 

In particular, the extension will only request up to 21 pages, and warn if there are more than 5 entries returned.